### PR TITLE
mtree: add recipe

### DIFF
--- a/recipes-security/mtree/mtree/mtree-getlogin.patch
+++ b/recipes-security/mtree/mtree/mtree-getlogin.patch
@@ -1,0 +1,49 @@
+Upstream-Status: Pending
+
+Handle NULL return from getlogin.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+diff --git a/create.c b/create.c
+index e2d24d3..583af9b 100644
+--- a/create.c
++++ b/create.c
+@@ -77,6 +77,29 @@ static void     output(int, int *, const char *, ...) __attribute__ ((__format__
+ static int      statd(FTS *, FTSENT *, uid_t *, gid_t *, mode_t *, u_long *);
+ static void     statf(int, FTSENT *);
+ 
++char *my_getlogin()
++{
++        const char *s = getlogin();
++        if (s && *s)
++                return s;
++
++        struct passwd *p = getpwuid(geteuid());
++        char *ss;
++        if (p && p->pw_name) {
++                if (asprintf(&ss,"(no controlling terminal) %s",p->pw_name) < 0) {
++                        perror("asprintf");
++                        return NULL;
++                }
++        } else {
++                if (asprintf(&ss,"(no controlling terminal) #%d",geteuid()) < 0) {
++                        perror("asprintf");
++                        return NULL;
++            }
++        }
++
++        return ss;
++}
++
+ void
+ cwalk(void)
+ {
+@@ -92,7 +115,7 @@ cwalk(void)
+                 (void)gethostname(host, sizeof(host));
+                 (void)printf(
+                     "#\t   user: %s\n#\tmachine: %s\n",
+-                    getlogin(), host);
++                    my_getlogin(), host);
+                 (void)printf(
+                     "#\t   tree: %s\n#\t   date: %s",
+                     fullpath, ctime(&cl));

--- a/recipes-security/mtree/mtree_1.0.3.bb
+++ b/recipes-security/mtree/mtree_1.0.3.bb
@@ -1,0 +1,22 @@
+SUMMARY = "BSD directory hierarchy mapping tool"
+DESCRIPTION = "mtree compares a file hierarchy against a specification, creates a specification for a file hierarchy, or modifies a specification."
+
+SECTION = "utils"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bb19ea4eac951288efda4010c5c669a8"
+
+SRC_URI = "git://github.com/archiecobbs/mtree-port.git \
+           file://mtree-getlogin.patch \
+           "
+SRCREV = "172e1827c381ff3851cc99edb5fd89443cf260e9"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "openssl"
+
+inherit autotools
+
+do_configure_prepend() {
+    touch ${S}/NEWS ${S}/AUTHORS ${S}/ChangeLog
+}


### PR DESCRIPTION
Add recipe mtree port from BSD. Add a patch to handle null return
from getlogin.

Signed-off-by: Kai Kang <kai.kang@windriver.com>